### PR TITLE
Added warning and updated the existing warnings when configuration details are missing

### DIFF
--- a/src/CheckoutAuthCodeGrant/Controllers/CheckoutController.cs
+++ b/src/CheckoutAuthCodeGrant/Controllers/CheckoutController.cs
@@ -29,7 +29,7 @@
             // Return any error to display to the user.
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = TryGetErrorMessage(content);
+                var errorMessage = WebUtility.HtmlEncode(TryGetErrorMessage(content));
 
                 if (string.IsNullOrWhiteSpace(errorMessage))
                 {
@@ -73,7 +73,7 @@
             // Check that the request to get payment configurations was successful.
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = TryGetErrorMessage(content);
+                var errorMessage = WebUtility.HtmlEncode(TryGetErrorMessage(content));
 
                 if (string.IsNullOrWhiteSpace(errorMessage))
                 {
@@ -134,7 +134,7 @@
             // Check that the request to get the public key was successful.
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = TryGetErrorMessage(content);
+                var errorMessage = WebUtility.HtmlEncode(TryGetErrorMessage(content));
 
                 if (string.IsNullOrWhiteSpace(errorMessage))
                 {

--- a/src/CheckoutAuthCodeGrant/Controllers/HomeController.cs
+++ b/src/CheckoutAuthCodeGrant/Controllers/HomeController.cs
@@ -32,6 +32,18 @@
         /// </summary>
         private async Task FindPotentialApplicationErrors(HomeViewModel homeViewModel)
         {
+            // Check that the subscription key has been set.
+            if (string.IsNullOrWhiteSpace(Configuration.SubscriptionKey))
+            {
+                homeViewModel.ErrorsViewModel.Errors.Add(new ErrorViewModel
+                {
+                    Error = "Subscription key not configured",
+                    Description = "The subscription key represents Blackbaud's permission to you to use the SKY API functionality.  " +
+                                  "Without a subscription key this sample application is unauthorized to use Sky API functionality. " +
+                                  "You can find subscription key at <a href='https://developer.sky.blackbaud.com/developer'>SKY API developer account</a> page."
+                });
+            }
+
             // Check that this application's Sky API application ID has been set.
             if (string.IsNullOrWhiteSpace(homeViewModel.ApplicationId))
             {
@@ -39,7 +51,9 @@
                 {
                     Error = "Application ID not configured",
                     Description = "The application ID is used by Sky API to validate the calling application when making requests to Sky API.  " +
-                                  "Without an application ID this sample application will not be able to authenticate a user with Sky API or use Sky API functionality."
+                                  "Without an application ID this sample application will not be able to authenticate a user with Sky API or use Sky API functionality.  " +
+                                  "You can find application ID at <a href=' https://developer.blackbaud.com/apps/'>SKY API application</a> page."
+
                 });
             }
 
@@ -50,7 +64,8 @@
                 {
                     Error = "Application secret not configured",
                     Description = "The application secret is used by Sky API to validate the calling application when making requests to Sky API.  " +
-                                  "Without an application secret this sample application will not be able to authenticate a user with Sky API nor use Sky API functionality."
+                                  "Without an application secret this sample application will not be able to authenticate a user with Sky API nor use Sky API functionality.  " +
+                                  "You can find application secret at <a href=' https://developer.blackbaud.com/apps/'>SKY API application</a> page."
                 });
             }
 

--- a/src/CheckoutAuthCodeGrant/Views/Shared/_Errors.cshtml
+++ b/src/CheckoutAuthCodeGrant/Views/Shared/_Errors.cshtml
@@ -6,7 +6,7 @@
     {
         <div class="alert alert-danger" role="alert">
             <strong>@Html.ValueFor(m => error.Error)</strong>
-            <p>@Html.ValueFor(m => error.Description)</p>
+            <p>@Html.Raw(error.Description)</p>
         </div>
     }
 </div>


### PR DESCRIPTION
Improvements to payments-checkout-authcodegrant-sample by adding a warning and updating the existing warnings when configuration details are missing.